### PR TITLE
Add close method to RubyTcpSender

### DIFF
--- a/lib/gelf/ruby_sender.rb
+++ b/lib/gelf/ruby_sender.rb
@@ -235,7 +235,13 @@ module GELF
         end
       end
     end
-
+    
+    def close
+      @sockets.each do |socket|
+      	socket.close
+      end
+    end
+    
     private
     def write_any(writers, message)
       writers.shuffle.each do |w|


### PR DESCRIPTION
Match the same functionality that RubyUdpSender has in allowing user of RubyTcpSender to close all sockets.
